### PR TITLE
БЛР3 P3334 Бабенко Даниил

### DIFF
--- a/lab3/Makefile
+++ b/lab3/Makefile
@@ -1,0 +1,6 @@
+obj-m := iostat_module.o
+
+all:
+    make -C /lib/modules/$(shell uname -r)/build M=$(PWD) modules
+clean:
+    make -C /lib/modules/$(shell uname -r)/build M=$(PWD) clean

--- a/lab3/compilation.sh
+++ b/lab3/compilation.sh
@@ -1,0 +1,11 @@
+sudo rmmod iostat_module.ko
+echo "Module unloaded"
+make
+echo "Compiled"
+g++ iostat_user.c -o iostat_user
+echo "User compiled"
+sudo insmod iostat_module.ko
+echo "Module loaded"
+lsmod | grep iostat_module
+sudo ./iostat_user /dev/sda
+echo "End"

--- a/lab3/iostat_data.h
+++ b/lab3/iostat_data.h
@@ -1,0 +1,14 @@
+#ifndef IOSTAT_DATA_H
+#define IOSTAT_DATA_H
+
+#define BDEVNAME_SIZE 256
+
+struct iostat_data {
+    unsigned long long read_sectors;
+    unsigned long long write_sectors;
+    unsigned long long read_ios;
+    unsigned long long write_ios;
+    char path[BDEVNAME_SIZE];
+};
+
+#endif

--- a/lab3/iostat_module.c
+++ b/lab3/iostat_module.c
@@ -153,12 +153,12 @@ static void __exit my_module_exit(void) {
     class_destroy(dev_class); 
     unregister_chrdev_region(dev_num, 1);
 
-printk(KERN_INFO "Module unloaded!\n"); 
+    printk(KERN_INFO "Module unloaded!\n"); 
 } 
  
 module_init(my_module_init); 
 module_exit(my_module_exit); 
  
 MODULE_LICENSE("GPL"); 
-MODULE_AUTHOR("Your Name"); 
+MODULE_AUTHOR("Daniel"); 
 MODULE_DESCRIPTION("IOStat Kernel Module");

--- a/lab3/iostat_module.c
+++ b/lab3/iostat_module.c
@@ -1,0 +1,164 @@
+#include <linux/module.h>
+#include <linux/kernel.h>
+#include <linux/fs.h>
+#include <linux/cdev.h>
+#include <linux/device.h>
+#include <linux/uaccess.h>
+#include <linux/ioctl.h>
+#include <linux/slab.h>
+#include <linux/blkdev.h>
+#include <linux/string.h>
+#include <linux/seq_file.h>
+#include <linux/kdev_t.h>
+#include <linux/stat.h>
+
+#define IOCTL_GET_IOSTAT _IOWR('k', 0, struct iostat_data)
+#define SYSFS_PATH_MAX 256
+#define BDEVNAME_SIZE 256
+
+struct iostat_data {
+    unsigned long long read_sectors;
+    unsigned long long write_sectors;
+    unsigned long long read_ios;
+    unsigned long long write_ios;
+    char path[BDEVNAME_SIZE];
+};
+
+static dev_t dev_num;
+static struct class* dev_class;
+static struct cdev cdev;
+static struct device* device;
+
+
+static int read_sysfs_file(const char* path, unsigned long long* value) {
+    struct file* f = filp_open(path, O_RDONLY, 0);
+    char buf[32];
+    int ret = 0;
+    loff_t pos = 0;
+    if (IS_ERR(f)) {
+        return -PTR_ERR(f);
+    }
+
+    ret = kernel_read(f, buf, sizeof(buf)-1, &pos);
+    printk(KERN_INFO "OK\n");
+    printk(KERN_INFO "iRet: %d\n", ret);
+    if (ret < 0) {
+        filp_close(f, NULL);
+        return ret;
+    }
+    buf[ret] = '\0';
+    *value = simple_strtoull(buf, NULL, 10);
+    filp_close(f, NULL);
+    return 0;
+}
+
+static long device_ioctl(struct file* file, unsigned int cmd, unsigned long arg) {
+    struct iostat_data data;
+    struct block_device *bdev = NULL;
+    char sysfs_path[SYSFS_PATH_MAX];
+    int ret = 0;
+
+     if (_IOC_TYPE(cmd) != 'k' || _IOC_NR(cmd) != 0) {
+        return -ENOTTY;
+    }
+
+     if (cmd == IOCTL_GET_IOSTAT) {
+        if (copy_from_user(&data, (struct iostat_data __user *)arg, sizeof(data))) {
+             return -EFAULT;
+        }
+
+        bdev = blkdev_get_by_path(data.path, FMODE_READ | FMODE_WRITE, NULL);
+        if (IS_ERR(bdev)) {
+           return PTR_ERR(bdev);
+        }
+
+        printk(KERN_INFO "iostat_module: block device name: %s\n", bdev->bd_disk->disk_name);
+        snprintf(sysfs_path, SYSFS_PATH_MAX, "/sys/block/%s/stat", bdev->bd_disk->disk_name);
+         
+        unsigned long long values[11];
+
+         ret = read_sysfs_file(sysfs_path, &values[0]);
+         if(ret < 0) {
+              goto out;
+         }
+
+          data.read_ios = values[0];
+          data.read_sectors = values[2];
+          data.write_ios = values[4];
+          data.write_sectors = values[6];
+
+
+         if (copy_to_user((struct iostat_data __user *)arg, &data, sizeof(data))) {
+              ret = -EFAULT;
+              goto out;
+         }
+
+
+      out:
+           blkdev_put(bdev, FMODE_READ);
+           return ret;
+
+    }
+    return -ENOTTY;
+}
+ 
+static int device_open(struct inode* inode, struct file* file) { 
+    printk(KERN_INFO "Device opened.\n"); 
+    return 0; 
+} 
+ 
+static int device_release(struct inode* inode, struct file* file) { 
+    printk(KERN_INFO "Device closed.\n"); 
+    return 0; 
+} 
+
+static const struct file_operations fops = { 
+    .owner = THIS_MODULE, 
+    .open = device_open, 
+    .release = device_release, 
+    .unlocked_ioctl = device_ioctl, 
+}; 
+  
+static int __init my_module_init(void) { 
+    if (alloc_chrdev_region(&dev_num, 0, 1, "iostat_device") < 0) { 
+        return -1; 
+    } 
+ 
+    if ((dev_class = class_create(THIS_MODULE, "iostat_device_class")) == NULL) { 
+        unregister_chrdev_region(dev_num, 1); 
+        return -1; 
+    } 
+ 
+    if ((device = device_create(dev_class, NULL, dev_num, NULL, "iostat_device")) == NULL) { 
+        class_destroy(dev_class); 
+        unregister_chrdev_region(dev_num, 1); 
+        return -1; 
+    } 
+ 
+    cdev_init(&cdev, &fops); 
+    if (cdev_add(&cdev, dev_num, 1) < 0) { 
+        device_destroy(dev_class, dev_num); 
+        class_destroy(dev_class); 
+        unregister_chrdev_region(dev_num, 1); 
+        return -1; 
+    } 
+ 
+    printk(KERN_INFO "Module loaded!\n"); 
+    return 0; 
+} 
+  
+static void __exit my_module_exit(void) { 
+    cdev_del(&cdev); 
+    device_destroy(dev_class, dev_num); 
+    class_destroy(dev_class); 
+    unregister_chrdev_region(dev_num, 1);
+
+printk(KERN_INFO "Module unloaded!\n"); 
+} 
+ 
+module_init(my_module_init); 
+module_exit(my_module_exit); 
+ 
+MODULE_LICENSE("GPL"); 
+MODULE_AUTHOR("Your Name"); 
+MODULE_DESCRIPTION("IOStat Kernel Module");

--- a/lab3/iostat_module.c
+++ b/lab3/iostat_module.c
@@ -11,18 +11,11 @@
 #include <linux/seq_file.h>
 #include <linux/kdev_t.h>
 #include <linux/stat.h>
+#include "iostat_data.h"
 
 #define IOCTL_GET_IOSTAT _IOWR('k', 0, struct iostat_data)
 #define SYSFS_PATH_MAX 256
 #define BDEVNAME_SIZE 256
-
-struct iostat_data {
-    unsigned long long read_sectors;
-    unsigned long long write_sectors;
-    unsigned long long read_ios;
-    unsigned long long write_ios;
-    char path[BDEVNAME_SIZE];
-};
 
 static dev_t dev_num;
 static struct class* dev_class;

--- a/lab3/iostat_module.c
+++ b/lab3/iostat_module.c
@@ -22,6 +22,116 @@ static struct class* dev_class;
 static struct cdev cdev;
 static struct device* device;
 
+// static int read_proc_diskstats(const char* device_name, unsigned long long *values) {
+//     struct file *f;
+//     char buf[4096];
+//     int ret, i;
+//     loff_t pos = 0;
+//     char *line, *token, *line_copy;
+//     char disk_name[256];
+//     bool found = false;
+//     char *buf_ptr; // <-- Added pointer to track position in buf
+
+//     f = filp_open("/proc/diskstats", O_RDONLY, 0);
+//     if (IS_ERR(f)) {
+//         printk(KERN_ERR "iostat_module: Error opening /proc/diskstats\n");
+//         return -PTR_ERR(f);
+//     }
+
+//     ret = kernel_read(f, buf, sizeof(buf) - 1, &pos);
+//     if (ret < 0) {
+//         printk(KERN_ERR "iostat_module: Error reading /proc/diskstats\n");
+//         filp_close(f, NULL);
+//         return ret;
+//     }
+//     buf[ret] = '\0';
+
+//     buf_ptr = buf; // <-- Initialize the pointer to the beginning of the buffer
+
+//     while ((line = strsep(&buf_ptr, "\n")) != NULL) { // <-- Use buf_ptr instead of &buf
+//         if (strlen(line) == 0) continue;
+
+//         line_copy = kstrdup(line, GFP_KERNEL);
+//         if (!line_copy) {
+//             filp_close(f, NULL);
+//             return -ENOMEM;
+//         }
+
+//         i = 0;
+//         token = line_copy;
+//         while ((token = strsep(&line_copy, " ")) != NULL) {
+//              if (strlen(token) == 0) continue;
+//              if (i == 2) {
+//                  strncpy(disk_name, token, sizeof(disk_name) - 1);
+//                  disk_name[sizeof(disk_name) - 1] = '\0';
+//                  if (strcmp(disk_name, device_name) == 0) {
+//                      found = true;
+//                  }
+//                 break;
+//              }
+//              if(found && i >= 3 && i < 14) {
+//                 values[i -3] = simple_strtoull(token, NULL, 10);
+//             }
+//              i++;
+//          }
+//         kfree(line_copy);
+//          if (found) break;
+//     }
+
+//     filp_close(f, NULL);
+
+//     if (!found) {
+//         printk(KERN_ERR "iostat_module: Device %s not found in /proc/diskstats\n", device_name);
+//         return -ENODEV;
+//     }
+//     return 0;
+// }
+
+
+// static long device_ioctl(struct file* file, unsigned int cmd, unsigned long arg) {
+//     struct iostat_data data;
+//     struct block_device *bdev = NULL;
+//     int ret = 0;
+//     char device_name[256];
+
+//      if (_IOC_TYPE(cmd) != 'k' || _IOC_NR(cmd) != 0) {
+//         return -ENOTTY;
+//     }
+
+//     if (cmd == IOCTL_GET_IOSTAT) {
+//         if (copy_from_user(&data, (struct iostat_data __user *)arg, sizeof(data))) {
+//              return -EFAULT;
+//         }
+        
+//          bdev = blkdev_get_by_path(data.path, FMODE_READ | FMODE_WRITE, NULL);
+//          if (IS_ERR(bdev)) {
+//            return PTR_ERR(bdev);
+//           }
+
+//         strncpy(device_name, bdev->bd_disk->disk_name, sizeof(device_name) -1);
+//            device_name[sizeof(device_name) -1] = '\0';
+
+//         unsigned long long values[11];
+//         ret = read_proc_diskstats(device_name, values);
+//         if(ret < 0) {
+//             goto out;
+//         }
+//         data.read_ios = values[0];
+//         data.read_sectors = values[2];
+//         data.write_ios = values[4];
+//         data.write_sectors = values[6];
+
+//          if (copy_to_user((struct iostat_data __user *)arg, &data, sizeof(data))) {
+//             ret = -EFAULT;
+//             goto out;
+//        }
+//       out:
+//         blkdev_put(bdev, FMODE_READ);
+//         return ret;
+//     }
+//     return -ENOTTY;
+// }
+
 
 static int read_sysfs_file(const char* path, unsigned long long* value) {
     struct file* f = filp_open(path, O_RDONLY, 0);

--- a/lab3/iostat_user.c
+++ b/lab3/iostat_user.c
@@ -1,0 +1,62 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <string.h>
+#include <sys/ioctl.h>
+#include <errno.h>
+#include <linux/fs.h>
+#include <sys/stat.h>
+
+#define IOCTL_GET_IOSTAT _IOWR('k', 0, struct iostat_data)
+#define BDEVNAME_SIZE 256
+
+struct iostat_data {
+    unsigned long long read_sectors;
+    unsigned long long write_sectors;
+    unsigned long long read_ios;
+    unsigned long long write_ios;
+    char path[BDEVNAME_SIZE];
+};
+
+int main(int argc, char *argv[]) {
+    int fd;
+    struct iostat_data data;
+    struct stat st;
+
+    if(argc != 2){
+        fprintf(stderr, "Usage: %s <device_node>\n", argv[0]);
+        return 1;
+    }
+    
+    if (stat(argv[1], &st) < 0) {
+        fprintf(stderr, "iostat_user: invalid device path\n");
+        return 1;
+    }
+    
+    strncpy(data.path, argv[1], sizeof(data.path)-1);
+    data.path[sizeof(data.path) - 1] = '\0';
+
+    fd = open("/dev/iostat_device", O_RDONLY);
+    if (fd < 0) {
+        fprintf(stderr, "Failed to open device: %s\n", strerror(errno));
+        return 1;
+    } else {
+        printf("Success in opening device\n");
+    }
+    
+    if (ioctl(fd, IOCTL_GET_IOSTAT, &data) < 0) {
+        fprintf(stderr, "ioctl failed: %s\n", strerror(errno));
+        close(fd);
+        return 1;
+    }
+
+    printf("I/O Statistics:\n");
+    printf("  Read Sectors: %llu\n", data.read_sectors);
+    printf("  Write Sectors: %llu\n", data.write_sectors);
+    printf("  Read IOs:     %llu\n", data.read_ios);
+    printf("  Write IOs:    %llu\n", data.write_ios);
+    
+    close(fd);
+    return 0;
+}

--- a/lab3/iostat_user.c
+++ b/lab3/iostat_user.c
@@ -11,14 +11,6 @@
 #define IOCTL_GET_IOSTAT _IOWR('k', 0, struct iostat_data)
 #define BDEVNAME_SIZE 256
 
-struct iostat_data {
-    unsigned long long read_sectors;
-    unsigned long long write_sectors;
-    unsigned long long read_ios;
-    unsigned long long write_ios;
-    char path[BDEVNAME_SIZE];
-};
-
 int main(int argc, char *argv[]) {
     int fd;
     struct iostat_data data;

--- a/lab3/iostat_user.c
+++ b/lab3/iostat_user.c
@@ -7,6 +7,7 @@
 #include <errno.h>
 #include <linux/fs.h>
 #include <sys/stat.h>
+#include "iostat_data.h"
 
 #define IOCTL_GET_IOSTAT _IOWR('k', 0, struct iostat_data)
 #define BDEVNAME_SIZE 256


### PR DESCRIPTION
БЛР3 P3334 Бабенко Даниил Александрович
Базовый трек, оценка 4. ЛР 3.
Вариант: ioctl: iostat

## Описание изменений

Костяк лабы, а именно:
- Модуль ядра iostat_module.c
- Пользовательская программа iostat_user.c
- Доп. файлы (Makefile, скрипт для пересборок и переконфигураций).

Основная идея лабы: насколько я узнал, статистика по вводу-выводу устройств в ядре находится по адресу sys/block/<устройство>/stat, и я хочу добыть информацию при вызове пользовательской программы именно оттуда. Пока что код не работает, но ещё не разобрался, почему конкретно.

Ориентировался в плане идеи на (что уж греха таить) ГПТ и данную статью:
https://mydebianblog.blogspot.com/2013/02/sysfs-linux.html

ЛАБА ПОКА ЧТО НЕ РАБОЧАЯ, ревью необходимо!